### PR TITLE
Added property parsers related to home battery

### DIFF
--- a/src/echonet-lite/property-parser/02-7D-A0.js
+++ b/src/echonet-lite/property-parser/02-7D-A0.js
@@ -1,0 +1,4 @@
+const parser = (buf) => {
+  return buf.readUInt32BE()
+}
+module.exports = parser

--- a/src/echonet-lite/property-parser/02-7D-A4.js
+++ b/src/echonet-lite/property-parser/02-7D-A4.js
@@ -1,0 +1,4 @@
+const parser = (buf) => {
+  return buf.readUInt32BE()
+}
+module.exports = parser

--- a/src/echonet-lite/property-parser/02-7D-A5.js
+++ b/src/echonet-lite/property-parser/02-7D-A5.js
@@ -1,0 +1,4 @@
+const parser = (buf) => {
+  return buf.readUInt32BE()
+}
+module.exports = parser

--- a/src/echonet-lite/property-parser/02-7D-D3.js
+++ b/src/echonet-lite/property-parser/02-7D-D3.js
@@ -1,0 +1,4 @@
+const parser = (buf) => {
+  return buf.readInt32BE()
+}
+module.exports = parser

--- a/src/echonet-lite/property-parser/02-7D-E2.js
+++ b/src/echonet-lite/property-parser/02-7D-E2.js
@@ -1,0 +1,4 @@
+const parser = (buf) => {
+  return buf.readUInt32BE()
+}
+module.exports = parser

--- a/test/echonet-lite/property-parser/02-7D-A0.test.js
+++ b/test/echonet-lite/property-parser/02-7D-A0.test.js
@@ -1,0 +1,7 @@
+const parser = require('../../../src/echonet-lite/property-parser/02-7D-A0.js')
+
+test('parse', () => {
+  expect(parser(Buffer.from('3B9AC9FF', 'hex'))).toBe(999999999)
+  expect(parser(Buffer.from('00000001', 'hex'))).toBe(1)
+  expect(parser(Buffer.from('00000000', 'hex'))).toBe(0)
+})

--- a/test/echonet-lite/property-parser/02-7D-A4.test.js
+++ b/test/echonet-lite/property-parser/02-7D-A4.test.js
@@ -1,0 +1,6 @@
+const parser = require('../../../src/echonet-lite/property-parser/02-7D-A4.js')
+
+test('parse', () => {
+  expect(parser(Buffer.from('00000000', 'hex'))).toBe(0)
+  expect(parser(Buffer.from('3B9AC9FF', 'hex'))).toBe(999999999)
+})

--- a/test/echonet-lite/property-parser/02-7D-A5.test.js
+++ b/test/echonet-lite/property-parser/02-7D-A5.test.js
@@ -1,0 +1,6 @@
+const parser = require('../../../src/echonet-lite/property-parser/02-7D-A5.js')
+
+test('parse', () => {
+  expect(parser(Buffer.from('00000000', 'hex'))).toBe(0)
+  expect(parser(Buffer.from('3B9AC9FF', 'hex'))).toBe(999999999)
+})

--- a/test/echonet-lite/property-parser/02-7D-D3.test.js
+++ b/test/echonet-lite/property-parser/02-7D-D3.test.js
@@ -1,0 +1,9 @@
+const parser = require('../../../src/echonet-lite/property-parser/02-7D-D3.js')
+
+test('parse', () => {
+  expect(parser(Buffer.from('3B9AC9FF', 'hex'))).toBe(999999999)
+  expect(parser(Buffer.from('00000001', 'hex'))).toBe(1)
+  expect(parser(Buffer.from('00000000', 'hex'))).toBe(0)
+  expect(parser(Buffer.from('FFFFFFFF', 'hex'))).toBe(-1)
+  expect(parser(Buffer.from('C4653601', 'hex'))).toBe(-999999999)
+})

--- a/test/echonet-lite/property-parser/02-7D-E2.test.js
+++ b/test/echonet-lite/property-parser/02-7D-E2.test.js
@@ -1,0 +1,6 @@
+const parser = require('../../../src/echonet-lite/property-parser/02-7D-E2.js')
+
+test('parse', () => {
+  expect(parser(Buffer.from('00000000', 'hex'))).toBe(0)
+  expect(parser(Buffer.from('3B9AC9FF', 'hex'))).toBe(999999999)
+})


### PR DESCRIPTION
- Home battery class [spec P 278](https://echonet.jp/wp/wp-content/uploads/pdf/General/Standard/Release/Release_Q/Appendix_Release_Q.pdf)
    - `0xA0`: effective capacity
    - `0xA4`: rechargeable amount
    - `0xA5`: dischargeable amount
    - `0xD3`: instant charge/discharge amount